### PR TITLE
Fix image stretching on Safari

### DIFF
--- a/src/components/manim-example.scss
+++ b/src/components/manim-example.scss
@@ -70,7 +70,7 @@
             width: 100%;
             img {
                 width: inherit;
-                height: fit-content;
+                height: auto;
             }
             video {
                 width: inherit;


### PR DESCRIPTION
In safari the aspect ratio of squares and circles is stretched in the y-direction, this PR fixes that

<img width="646" alt="Screenshot 2021-11-16 at 5 35 33 PM" src="https://user-images.githubusercontent.com/90276965/141982401-56bd91e3-7d70-4d8a-b18c-b3904151ae07.png">
<img width="646" alt="Screenshot 2021-11-16 at 5 35 17 PM" src="https://user-images.githubusercontent.com/90276965/141982422-6aae730a-41e6-4fdb-8de4-d0da49edda86.png">

